### PR TITLE
Use original square logo adapted to practical svg

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,27 +10,12 @@
 <header class="m-2down">
   <h1 class="site-title m-auto m-2down">
     <a href="" rel="home" class="decor-none">
-      <svg xmlns="http://www.w3.org/2000/svg"
-        role="img"
-        width="160"
-        height="160"
-        viewBox="0 0 1600 1600"
-        style="border-radius:50%; display:inline;">
+      <svg xmlns="http://www.w3.org/2000/svg" width="240" height="240" viewBox="0 0 2400 2400">
         <title>subpicture</title>
-        <rect x="0" y="0" width="1600" height="1600" fill="yellow" />
-        <text x="100" y="890" fill="indigo" textLength="1400px" font-family="arial,sans-serif" font-weight="700" font-size="900px">sub</text>
-        <text x="100" y="1100" fill="indigo" textLength="1000px" font-family="arial,sans-serif" font-weight="700" font-size="344px">picture</text>
-      </svg>
-      <svg xmlns="http://www.w3.org/2000/svg"
-        role="img"
-        width="160"
-        height="160"
-        viewBox="0 0 1600 1600"
-        style="border-radius:50%; display:none;">
-        <title>subpicture</title>
-        <rect x="0" y="0" width="1600" height="1600" fill="yellow" />
-        <text x="100" y="890" fill="indigo" textLength="1400px" font-family="arial,sans-serif" font-weight="700" font-size="900px">sub</text>
-        <text x="100" y="1220" fill="indigo" textLength="1400px" font-family="arial,sans-serif" font-weight="700" font-size="556px">picture</text>
+        <rect x="0" y="0" width="2400" height="2400" fill="#efefef" />
+        <rect x="230" y="600" width="1086" height="668" fill="#111" />
+        <text x="245" y="1149" fill="#efefef" style="font:700 600px arial,sans-serif">sub</text>
+        <text x="230" y="1749" fill="#111" style="font:700 600px arial,sans-serif">picture</text>
       </svg>
     </a>
   </h1>


### PR DESCRIPTION
- [codepen lite](https://codepen.io/ryanve/pen/vzgM`ja)
- [codepen nite](https://codepen.io/ryanve/pen/jvyoQL)
- adjusted from original to afford circular crop
- upsized to `240px` because this is `25%` and it looks dope