### PR TITLE
Link to Patreon overview

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
   <p class="m-auto">San Francisco photo project ETA EOY 2018
   <p class="m-auto">Creator is <a href="http://ryanve.com">Ryan Van Etten</a> who made <a href="http://amplifiedny.com">amplifiedNY</a>
   <p class="m-auto">Follow on
-    <a class="case-lower" href="https://www.patreon.com/subpicture">Patreon</a>
+    <a class="case-lower" href="https://www.patreon.com/subpicture/overview">Patreon</a>
     <a class="case-lower" href="https://www.facebook.com/subpicture">Facebook</a>
     <a class="case-lower" href="https://www.instagram.com/subpicture/">Instagram</a>
     <a class="case-lower" href="https://vsco.co/subpicture">VSCO</a>


### PR DESCRIPTION
Other was redirecting to posts. We want [the overview](https://www.patreon.com/subpicture/overview) at least for now :)